### PR TITLE
Fix issue 23

### DIFF
--- a/method/resource.py
+++ b/method/resource.py
@@ -43,6 +43,10 @@ class Resource:
         return self.client(path).GET().json().get('data')
 
     @MethodError.catch
+    def _get_with_sub_path_and_params(self, path: str, params: Dict) -> Any:
+        return self.client(path).GET(params=params).json().get('data')
+
+    @MethodError.catch
     def _list(self, params: Optional[Dict] = None) -> List[Any]:
         return self.client.GET(params=params).json().get('data')
 

--- a/method/resources/Entity.py
+++ b/method/resources/Entity.py
@@ -61,6 +61,21 @@ CreditReportBureausLiterals = Literal[
     'transunion'
 ]
 
+EntitySensitiveFieldsLiterals = Literal[
+    'first_name',
+    'last_name',
+    'phone',
+    'phone_history',
+    'email',
+    'dob',
+    'address',
+    'address_history',
+    'ssn_4',
+    'ssn_6',
+    'ssn_9',
+    'identities'
+]
+
 
 class EntityIndividual(TypedDict):
     first_name: Optional[str]
@@ -182,7 +197,7 @@ class EntityCreditScoresResponse(TypedDict):
     error: Optional[ResourceError]
     created_at: str
     updated_at: str
-    
+
 
 class EntityCreditScoresFactorsType(TypedDict):
     code: str
@@ -204,7 +219,7 @@ class EntityCreditScoresResponse(TypedDict):
     error: Optional[ResourceError]
     created_at: str
     updated_at: str
-    
+
 
 class AnswerOpts(TypedDict):
     question_id: str
@@ -305,7 +320,7 @@ class EntityResource(Resource):
 
     def get_credit_score(self, _id: str) -> EntityQuestionResponse:
         return super(EntityResource, self)._get_with_sub_path('{_id}/credit_score'.format(_id=_id))
-    
+
     def get_credit_scores(self, _id: str, crs_id: str) -> EntityCreditScoresResponse:
         return super(EntityResource, self)._get_with_sub_path('{_id}/credit_scores/{crs_id}'.format(_id=_id, crs_id=crs_id))
 
@@ -327,8 +342,11 @@ class EntityResource(Resource):
     def get_credit_score(self, _id: str) -> EntityQuestionResponse:
         return super(EntityResource, self)._get_with_sub_path('{_id}/credit_score'.format(_id=_id))
 
-    def get_sensitive_fields(self, _id: str) -> EntitySensitiveResponse:
-        return super(EntityResource, self)._get_with_sub_path('{_id}/sensitive'.format(_id=_id))
+    def get_sensitive_fields(self, _id: str, fields: List[EntitySensitiveFieldsLiterals]) -> EntitySensitiveResponse:
+        return super(EntityResource, self)._get_with_sub_path_and_params(
+            '{_id}/sensitive'.format(_id=_id),
+            {'fields[]': fields},
+        )
 
     def withdraw_consent(self, _id: str) -> Entity:
         return super(EntityResource, self)._create_with_sub_path(


### PR DESCRIPTION
Fix issue #23 by allowing the caller to specify the exact secret fields that one wants to retirieve.

There does not seem to be any test inthe repository, so here are the results of the manual testing.

```python
# No `fields` argument passed
>>> method_sdk.entities.get_sensitive_fields("ent_kHAqhRjQVVVpr")
TypeError: EntityResource.get_sensitive_fields() missing 1 required positional argument: 'fields'

# No fields requested
>>> method_sdk.entities.get_sensitive_fields("ent_kHAqhRjQVVVpr", [])
'Field "fields" is required. Verify your request and try again.'

# Allowed filed requested
>>> method_sdk.entities.get_sensitive_fields("ent_A6nGi7Vfdzzxe", ['dob'])
{
    'first_name': None,
    'last_name': None,
    'phone': None,
    'phone_history': [],
    'email': None,
    'dob': '2000-01-01',
    'address': None,
    'address_history': [],
    'all_addresses': [],
    'ssn_4': None,
    'ssn_6': None,
    'ssn_9': None,
    'identities': []
}

# Multiple allowed fields requested
>>> method_sdk.entities.get_sensitive_fields("ent_kHAqhRjQVVVpr", ['dob', 'address'])
{
    'first_name': None,
    'last_name': None,
    'phone': None,
    'phone_history': [],
    'email': None,
    'dob': '2000-01-01',
    'address': {
        'line1': '705 Blanton Dr',
        'line2': None,
        'city': 'Sherman',
        'state': 'TX',
        'zip': '75092'
    },
    'address_history': [],
    'all_addresses': [],
    'ssn_4': None,
    'ssn_6': None,
    'ssn_9': None,
    'identities': []
}

# Even more allowed fields requested
>>> method_sdk.entities.get_sensitive_fields("ent_kHAqhRjQVVVpr", ['dob', 'address', 'ssn_9'])
{
    'first_name': None,
    'last_name': None,
    'phone': None,
    'phone_history': [],
    'email': None,
    'dob': '2000-01-01',
    'address': {
        'line1': '705 Blanton Dr',
        'line2': None,
        'city': 'Sherman',
        'state': 'TX',
        'zip': '75092'
    },
    'address_history': [],
    'all_addresses': [],
    'ssn_4': None,
    'ssn_6': None,
    'ssn_9': '1234356789',
    'identities': []
}

# Prohibited field provided (seems like `first_name` is not "authorized" in our dev environment)
>>> method_sdk.entities.get_sensitive_fields("ent_kHAqhRjQVVVpr", ['dob', 'first_name'])
We were unable to understand your request. Verify your request and try again.

# Unknow field requested
>>>method_sdk.entities.get_sensitive_fields("ent_kHAqhRjQVVVpr", ['dob', 'address', 'blah-blah'])
Field "fields[2]" must be one of [first_name, last_name, phone, phone_history, dob, address, email, address_history, ssn_4, ssn_6, ssn_9, identities]. Verify your request and try again.
```