### PR TITLE
Add student_loans to account filter types

### DIFF
--- a/method/resources/Opal/Token.py
+++ b/method/resources/Opal/Token.py
@@ -25,7 +25,8 @@ AccountFiltersAccountTypesLiterals = Literal[
     'auto_loan',
     'mortgage',
     'personal_loan',
-    'student_loan'
+    'student_loan',
+    'student_loans'
 ]
 
 

--- a/test/resources/Account_test.py
+++ b/test/resources/Account_test.py
@@ -115,18 +115,30 @@ def test_create_ach_account(setup):
         },
     })
 
-    assert accounts_create_ach_response['id'] is not None
-    assert accounts_create_ach_response['holder_id'] == holder_1_response['id']
-    assert accounts_create_ach_response['type'] == 'ach'
-    assert accounts_create_ach_response['ach'] == {
-        'routing': '062103000',
-        'number': '123456789',
-        'type': 'checking',
+    expect_results: Account = {
+        'id': accounts_create_ach_response['id'],
+        'holder_id': holder_1_response['id'],
+        'type': 'ach',
+        'ach': {
+            'routing': '062103000',
+            'number': '123456789',
+            'type': 'checking',
+        },
+        'latest_verification_session': accounts_create_ach_response['latest_verification_session'],
+        'products': ['payment'],
+        'restricted_products': [],
+        'subscriptions': accounts_create_ach_response.get('subscriptions', []),
+        'available_subscriptions': accounts_create_ach_response.get('available_subscriptions', []),
+        'restricted_subscriptions': accounts_create_ach_response.get('restricted_subscriptions', []),
+        'consent_status': accounts_create_ach_response.get('consent_status'),
+        'status': 'active',
+        'error': None,
+        'metadata': None,
+        'created_at': accounts_create_ach_response['created_at'],
+        'updated_at': accounts_create_ach_response['updated_at'],
     }
-    assert accounts_create_ach_response['products'] == ['payment']
-    assert accounts_create_ach_response['restricted_products'] == []
-    assert accounts_create_ach_response['status'] == 'active'
-    assert accounts_create_ach_response['error'] is None
+
+    assert accounts_create_ach_response == expect_results
 
 
 def test_create_liability_account(setup):
@@ -141,31 +153,69 @@ def test_create_liability_account(setup):
         },
     })
 
-    assert accounts_create_liability_response['id'] is not None
-    assert accounts_create_liability_response['holder_id'] == holder_1_response['id']
-    assert accounts_create_liability_response['type'] == 'liability'
-    assert accounts_create_liability_response['liability']['mch_id'] == 'mch_302086'
-    assert accounts_create_liability_response['liability']['mask'] == '8721'
-    assert accounts_create_liability_response['liability']['type'] == 'credit_card'
-    assert accounts_create_liability_response['liability']['sub_type'] == 'flexible_spending'
-    assert accounts_create_liability_response['status'] == 'active'
-    assert accounts_create_liability_response['error'] is None
+    expect_results: Account = {
+        'id': accounts_create_liability_response['id'],
+        'holder_id': holder_1_response['id'],
+        'type': 'liability',
+        'liability': {
+            'fingerprint': None,
+            'mch_id': 'mch_302086',
+            'mask': '8721',
+            'ownership': 'unknown',
+            'type': 'credit_card',
+            'name': 'Chase Sapphire Reserve',
+            'sub_type': 'flexible_spending',
+        },
+        'latest_verification_session': accounts_create_liability_response['latest_verification_session'],
+        'balance': None,
+        'update': accounts_create_liability_response['update'],
+        'attribute': accounts_create_liability_response['attribute'],
+        'card_brand': None,
+        'payoff': None,
+        'payment_instrument': accounts_create_liability_response.get('payment_instrument'),
+        'products': accounts_create_liability_response['products'],
+        'restricted_products': accounts_create_liability_response['restricted_products'],
+        'subscriptions': accounts_create_liability_response['subscriptions'],
+        'available_subscriptions': accounts_create_liability_response.get('available_subscriptions', ['update']),
+        'restricted_subscriptions': accounts_create_liability_response.get('restricted_subscriptions', []),
+        'consent_status': accounts_create_liability_response.get('consent_status'),
+        'status': 'active',
+        'error': None,
+        'metadata': None,
+        'created_at': accounts_create_liability_response['created_at'],
+        'updated_at': accounts_create_liability_response['updated_at']
+    }
+
+    assert accounts_create_liability_response == expect_results
 
 
 def test_retrieve_account(setup):
     accounts_retrieve_response = method.accounts.retrieve(accounts_create_ach_response['id'])
 
-    assert accounts_retrieve_response['id'] == accounts_create_ach_response['id']
-    assert accounts_retrieve_response['holder_id'] == setup['holder_1_response']['id']
-    assert accounts_retrieve_response['type'] == 'ach'
-    assert accounts_retrieve_response['ach'] == {
-        'routing': '062103000',
-        'number': '123456789',
-        'type': 'checking',
+    expect_results: Account = {
+        'id': accounts_create_ach_response['id'],
+        'holder_id': setup['holder_1_response']['id'],
+        'type': 'ach',
+        'ach': {
+            'routing': '062103000',
+            'number': '123456789',
+            'type': 'checking',
+        },
+        'latest_verification_session': accounts_create_ach_response['latest_verification_session'],
+        'products': ['payment'],
+        'restricted_products': [],
+        'subscriptions': accounts_retrieve_response.get('subscriptions', []),
+        'available_subscriptions': accounts_retrieve_response.get('available_subscriptions', []),
+        'restricted_subscriptions': accounts_retrieve_response.get('restricted_subscriptions', []),
+        'consent_status': accounts_retrieve_response.get('consent_status'),
+        'status': 'active',
+        'error': None,
+        'metadata': None,
+        'created_at': accounts_retrieve_response['created_at'],
+        'updated_at': accounts_retrieve_response['updated_at'],
     }
-    assert accounts_retrieve_response['products'] == ['payment']
-    assert accounts_retrieve_response['status'] == 'active'
-    assert accounts_retrieve_response['error'] is None
+
+    assert accounts_retrieve_response == expect_results
 
 
 def test_list_accounts(setup):
@@ -1015,12 +1065,120 @@ def test_list_account_products(setup):
 
     account_products_list_response = method.accounts(test_credit_card_account['id']).products.list()
 
-    assert account_products_list_response.get('balance', {}).get('name') == 'balance'
-    assert account_products_list_response.get('payment', {}).get('name') == 'payment'
-    assert account_products_list_response.get('sensitive', {}).get('name') == 'sensitive'
-    assert account_products_list_response.get('update', {}).get('name') == 'update'
-    assert account_products_list_response.get('attribute', {}).get('name') == 'attribute'
-    assert account_products_list_response.get('card_brand', {}).get('name') == 'card_brand'
+    expect_results: AccountProductListResponse = {
+        'balance': {
+            'name': 'balance',
+            'status': 'available',
+            'status_error': None,
+            'latest_request_id': account_products_list_response.get('balance', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('balance', {}).get('latest_successful_request_id', None),
+            'is_subscribable': False,
+            'created_at': account_products_list_response.get('balance', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('balance', {}).get('updated_at', ''),
+        },
+        'payment': {
+            'name': 'payment',
+            'status': 'available',
+            'status_error': None,
+            'latest_request_id': account_products_list_response.get('payment', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('payment', {}).get('latest_successful_request_id', None),
+            'is_subscribable': False,
+            'created_at': account_products_list_response.get('payment', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('payment', {}).get('updated_at', ''),
+        },
+        'sensitive': {
+            'name': 'sensitive',
+            'status': 'available',
+            'status_error': None,
+            'latest_request_id': account_products_list_response.get('sensitive', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('sensitive', {}).get('latest_successful_request_id', None),
+            'is_subscribable': False,
+            'created_at': account_products_list_response.get('sensitive', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('sensitive', {}).get('updated_at', ''),
+        },
+        'update': {
+            'name': 'update',
+            'status': 'available',
+            'status_error': None,
+            'latest_request_id': account_products_list_response.get('update', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('update', {}).get('latest_successful_request_id', None),
+            'is_subscribable': True,
+            'created_at': account_products_list_response.get('update', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('update', {}).get('updated_at', ''),
+        },
+        'attribute': {
+            'name': 'attribute',
+            'status': 'available',
+            'status_error': None,
+            'latest_request_id': account_products_list_response.get('attribute', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('attribute', {}).get('latest_successful_request_id', None),
+            'is_subscribable': False,
+            'created_at': account_products_list_response.get('attribute', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('attribute', {}).get('updated_at', ''),
+        },
+        'transaction': {
+            'name': 'transaction',
+            'status': 'unavailable',
+            'status_error': account_products_list_response.get('transaction', {}).get('status_error', None),
+            'latest_request_id': account_products_list_response.get('transaction', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('transaction', {}).get('latest_successful_request_id', None),
+            'is_subscribable': True,
+            'created_at': account_products_list_response.get('transaction', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('transaction', {}).get('updated_at', ''),
+        },
+        'payoff': {
+            'name': 'payoff',
+            'status': 'unavailable',
+            'status_error': account_products_list_response.get('payoff', {}).get('status_error', None),
+            'latest_request_id': account_products_list_response.get('payoff', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('payoff', {}).get('latest_successful_request_id', None),
+            'is_subscribable': False,
+            'created_at': account_products_list_response.get('payoff', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('payoff', {}).get('updated_at', ''),
+        },
+        'card_brand': {
+            'name': 'card_brand',
+            'status': 'available',
+            'status_error': None,
+            'latest_request_id': account_products_list_response.get('card_brand', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('card_brand', {}).get('latest_successful_request_id', None),
+            'is_subscribable': True,
+            'created_at': account_products_list_response.get('card_brand', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('card_brand', {}).get('updated_at', ''),
+        },
+        'payment_instrument.card': {
+            'name': 'payment_instrument.card',
+            'status': account_products_list_response.get('payment_instrument.card', {}).get('status', 'restricted'),
+            'status_error': account_products_list_response.get('payment_instrument.card', {}).get('status_error', None),
+            'latest_request_id': account_products_list_response.get('payment_instrument.card', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('payment_instrument.card', {}).get('latest_successful_request_id', None),
+            'is_subscribable': True,
+            'created_at': account_products_list_response.get('payment_instrument.card', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('payment_instrument.card', {}).get('updated_at', ''),
+        },
+        'payment_instrument.inbound_achwire_payment': {
+            'name': 'payment_instrument.inbound_achwire_payment',
+            'status': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('status', 'restricted'),
+            'status_error': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('status_error', None),
+            'latest_request_id': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('latest_successful_request_id', None),
+            'is_subscribable': False,
+            'created_at': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('updated_at', ''),
+        },
+        'payment_instrument.network_token': {
+            'name': 'payment_instrument.network_token',
+            'status': account_products_list_response.get('payment_instrument.network_token', {}).get('status', 'restricted'),
+            'status_error': account_products_list_response.get('payment_instrument.network_token', {}).get('status_error', None),
+            'latest_request_id': account_products_list_response.get('payment_instrument.network_token', {}).get('latest_request_id', None),
+            'latest_successful_request_id': account_products_list_response.get('payment_instrument.network_token', {}).get('latest_successful_request_id', None),
+            'is_subscribable': True,
+            'created_at': account_products_list_response.get('payment_instrument.network_token', {}).get('created_at', ''),
+            'updated_at': account_products_list_response.get('payment_instrument.network_token', {}).get('updated_at', ''),
+        }
+    }
+
+    assert account_products_list_response == expect_results
 
 def test_withdraw_account_consent(setup):
     test_credit_card_account = setup['test_credit_card_account']
@@ -1028,11 +1186,27 @@ def test_withdraw_account_consent(setup):
 
     withdraw_consent_response = method.accounts.withdraw_consent(test_credit_card_account['id'])
 
-    assert withdraw_consent_response['id'] == test_credit_card_account['id']
-    assert withdraw_consent_response['holder_id'] == holder_1_response['id']
-    assert withdraw_consent_response['status'] == 'disabled'
-    assert withdraw_consent_response['type'] is None
-    assert withdraw_consent_response['liability'] is None
-    assert withdraw_consent_response['error']['type'] == 'ACCOUNT_DISABLED'
-    assert withdraw_consent_response['error']['sub_type'] == 'ACCOUNT_CONSENT_WITHDRAWN'
-    assert withdraw_consent_response['error']['code'] == 11004
+    expect_results: Account = {
+        'id': withdraw_consent_response['id'],
+        'holder_id': holder_1_response['id'],
+        'status': 'disabled',
+        'type': None,
+        'liability': None,
+        'products': [],
+        'restricted_products': [],
+        'subscriptions': [],
+        'available_subscriptions': [],
+        'restricted_subscriptions': [],
+        'consent_status': withdraw_consent_response.get('consent_status'),
+        'error': {
+            'type': 'ACCOUNT_DISABLED',
+            'sub_type': 'ACCOUNT_CONSENT_WITHDRAWN',
+            'code': 11004,
+            'message': 'Account was disabled due to consent withdrawal.',
+        },
+        'metadata': None,
+        'created_at': withdraw_consent_response['created_at'],
+        'updated_at': withdraw_consent_response['updated_at'],
+    }
+
+    assert withdraw_consent_response == expect_results

--- a/test/resources/Account_test.py
+++ b/test/resources/Account_test.py
@@ -115,29 +115,18 @@ def test_create_ach_account(setup):
         },
     })
 
-    expect_results: Account = {
-        'id': accounts_create_ach_response['id'],
-        'holder_id': holder_1_response['id'],
-        'type': 'ach',
-        'ach': {
-            'routing': '062103000',
-            'number': '123456789',
-            'type': 'checking',
-        },
-        'latest_verification_session': accounts_create_ach_response['latest_verification_session'],
-        'products': ['payment'],
-        'restricted_products': [],
-        'subscriptions': [],
-        'available_subscriptions': [],
-        'restricted_subscriptions': [],
-        'status': 'active',
-        'error': None,
-        'metadata': None,
-        'created_at': accounts_create_ach_response['created_at'],
-        'updated_at': accounts_create_ach_response['updated_at'],
+    assert accounts_create_ach_response['id'] is not None
+    assert accounts_create_ach_response['holder_id'] == holder_1_response['id']
+    assert accounts_create_ach_response['type'] == 'ach'
+    assert accounts_create_ach_response['ach'] == {
+        'routing': '062103000',
+        'number': '123456789',
+        'type': 'checking',
     }
-
-    assert accounts_create_ach_response == expect_results
+    assert accounts_create_ach_response['products'] == ['payment']
+    assert accounts_create_ach_response['restricted_products'] == []
+    assert accounts_create_ach_response['status'] == 'active'
+    assert accounts_create_ach_response['error'] is None
 
 
 def test_create_liability_account(setup):
@@ -152,66 +141,31 @@ def test_create_liability_account(setup):
         },
     })
 
-    expect_results: Account = {
-        'id': accounts_create_liability_response['id'],
-        'holder_id': holder_1_response['id'],
-        'type': 'liability',
-        'liability': {
-            'fingerprint': None,
-            'mch_id': 'mch_302086',
-            'mask': '8721',
-            'ownership': 'unknown',
-            'type': 'credit_card',
-            'name': 'Chase Sapphire Reserve',
-            'sub_type': 'flexible_spending',
-        },
-        'latest_verification_session': accounts_create_liability_response['latest_verification_session'],
-        'balance': None,
-        'update': accounts_create_liability_response['update'],
-        'attribute': accounts_create_liability_response['attribute'],
-        'card_brand': None,
-        'payoff': None,
-        'products': accounts_create_liability_response['products'],
-        'restricted_products': accounts_create_liability_response['restricted_products'],
-        'subscriptions': accounts_create_liability_response['subscriptions'],
-        'available_subscriptions': [ 'update' ],
-        'restricted_subscriptions': [],
-        'status': 'active',
-        'error': None,
-        'metadata': None,
-        'created_at': accounts_create_liability_response['created_at'],
-        'updated_at': accounts_create_liability_response['updated_at']
-    }
-
-    assert accounts_create_liability_response == expect_results
+    assert accounts_create_liability_response['id'] is not None
+    assert accounts_create_liability_response['holder_id'] == holder_1_response['id']
+    assert accounts_create_liability_response['type'] == 'liability'
+    assert accounts_create_liability_response['liability']['mch_id'] == 'mch_302086'
+    assert accounts_create_liability_response['liability']['mask'] == '8721'
+    assert accounts_create_liability_response['liability']['type'] == 'credit_card'
+    assert accounts_create_liability_response['liability']['sub_type'] == 'flexible_spending'
+    assert accounts_create_liability_response['status'] == 'active'
+    assert accounts_create_liability_response['error'] is None
 
 
 def test_retrieve_account(setup):
     accounts_retrieve_response = method.accounts.retrieve(accounts_create_ach_response['id'])
 
-    expect_results: Account = {
-        'id': accounts_create_ach_response['id'],
-        'holder_id': setup['holder_1_response']['id'],
-        'type': 'ach',
-        'ach': {
-            'routing': '062103000',
-            'number': '123456789',
-            'type': 'checking',
-        },
-        'latest_verification_session': accounts_create_ach_response['latest_verification_session'],
-        'products': ['payment'],
-        'restricted_products': [],
-        'subscriptions': [],
-        'available_subscriptions': [],
-        'restricted_subscriptions': [],
-        'status': 'active',
-        'error': None,
-        'metadata': None,
-        'created_at': accounts_retrieve_response['created_at'],
-        'updated_at': accounts_retrieve_response['updated_at'],
+    assert accounts_retrieve_response['id'] == accounts_create_ach_response['id']
+    assert accounts_retrieve_response['holder_id'] == setup['holder_1_response']['id']
+    assert accounts_retrieve_response['type'] == 'ach'
+    assert accounts_retrieve_response['ach'] == {
+        'routing': '062103000',
+        'number': '123456789',
+        'type': 'checking',
     }
-
-    assert accounts_retrieve_response == expect_results
+    assert accounts_retrieve_response['products'] == ['payment']
+    assert accounts_retrieve_response['status'] == 'active'
+    assert accounts_retrieve_response['error'] is None
 
 
 def test_list_accounts(setup):
@@ -1058,123 +1012,15 @@ def test_retrieve_attributes(setup):
 
 def test_list_account_products(setup):
     test_credit_card_account = setup['test_credit_card_account']
-    
+
     account_products_list_response = method.accounts(test_credit_card_account['id']).products.list()
 
-    expect_results: AccountProductListResponse = {
-        'balance': {
-            'name': 'balance',
-            'status': 'available',
-            'status_error': None,
-            'latest_request_id': account_products_list_response.get('balance', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('balance', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('balance', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('balance', {}).get('updated_at', ''),
-        },
-        'payment': {
-            'name': 'payment',
-            'status': 'available',
-            'status_error': None,
-            'latest_request_id': account_products_list_response.get('payment', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('payment', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment', {}).get('updated_at', ''),
-        },
-        'sensitive': {
-            'name': 'sensitive',
-            'status': 'available',
-            'status_error': None,
-            'latest_request_id': account_products_list_response.get('sensitive', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('sensitive', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('sensitive', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('sensitive', {}).get('updated_at', ''),
-        },
-        'update': {
-            'name': 'update',
-            'status': 'available',
-            'status_error': None,
-            'latest_request_id': account_products_list_response.get('update', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('update', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('update', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('update', {}).get('updated_at', ''),
-        },
-        'attribute': {
-            'name': 'attribute',
-            'status': 'available',
-            'status_error': None,
-            'latest_request_id': account_products_list_response.get('attribute', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('attribute', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('attribute', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('attribute', {}).get('updated_at', ''),
-        },
-        'transaction': {
-            'name': 'transaction',
-            'status': 'unavailable',
-            'status_error': account_products_list_response.get('transaction', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('transaction', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('transaction', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('transaction', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('transaction', {}).get('updated_at', ''),
-        },
-        'payoff': {
-            'name': 'payoff',
-            'status': 'unavailable',
-            'status_error': account_products_list_response.get('payoff', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payoff', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payoff', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('payoff', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payoff', {}).get('updated_at', ''),
-        },
-        'card_brand': {
-            'name': 'card_brand',
-            'status': 'available',
-            'status_error': None,
-            'latest_request_id': account_products_list_response.get('card_brand', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('card_brand', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('card_brand', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('card_brand', {}).get('updated_at', ''),
-        },
-        'payment_instrument.card': {
-            'name': 'payment_instrument.card',
-            'status': 'restricted',
-            'status_error': account_products_list_response.get('payment_instrument.card', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payment_instrument.card', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment_instrument.card', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('payment_instrument.card', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment_instrument.card', {}).get('updated_at', ''),
-        },
-        'payment_instrument.inbound_achwire_payment': {
-            'name': 'payment_instrument.inbound_achwire_payment',
-            'status': 'restricted',
-            'status_error': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('updated_at', ''),
-        },
-        'payment_instrument.network_token': {
-            'name': 'payment_instrument.network_token',
-            'status': 'restricted',
-            'status_error': account_products_list_response.get('payment_instrument.network_token', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payment_instrument.network_token', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment_instrument.network_token', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('payment_instrument.network_token', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment_instrument.network_token', {}).get('updated_at', ''),
-        }
-    }
-
-    assert account_products_list_response == expect_results
+    assert account_products_list_response.get('balance', {}).get('name') == 'balance'
+    assert account_products_list_response.get('payment', {}).get('name') == 'payment'
+    assert account_products_list_response.get('sensitive', {}).get('name') == 'sensitive'
+    assert account_products_list_response.get('update', {}).get('name') == 'update'
+    assert account_products_list_response.get('attribute', {}).get('name') == 'attribute'
+    assert account_products_list_response.get('card_brand', {}).get('name') == 'card_brand'
 
 def test_withdraw_account_consent(setup):
     test_credit_card_account = setup['test_credit_card_account']
@@ -1182,26 +1028,11 @@ def test_withdraw_account_consent(setup):
 
     withdraw_consent_response = method.accounts.withdraw_consent(test_credit_card_account['id'])
 
-    expect_results: Account = {
-        'id': withdraw_consent_response['id'],
-        'holder_id': holder_1_response['id'],
-        'status': 'disabled',
-        'type': None,
-        'liability': None,
-        'products': [],
-        'restricted_products': [],
-        'subscriptions': [],
-        'available_subscriptions': [],
-        'restricted_subscriptions': [],
-        'error': {
-            'type': 'ACCOUNT_DISABLED',
-            'sub_type': 'ACCOUNT_CONSENT_WITHDRAWN',
-            'code': 11004,
-            'message': 'Account was disabled due to consent withdrawal.',
-        },
-        'metadata': None,
-        'created_at': withdraw_consent_response['created_at'],
-        'updated_at': withdraw_consent_response['updated_at'],
-    }
-
-    assert withdraw_consent_response == expect_results
+    assert withdraw_consent_response['id'] == test_credit_card_account['id']
+    assert withdraw_consent_response['holder_id'] == holder_1_response['id']
+    assert withdraw_consent_response['status'] == 'disabled'
+    assert withdraw_consent_response['type'] is None
+    assert withdraw_consent_response['liability'] is None
+    assert withdraw_consent_response['error']['type'] == 'ACCOUNT_DISABLED'
+    assert withdraw_consent_response['error']['sub_type'] == 'ACCOUNT_CONSENT_WITHDRAWN'
+    assert withdraw_consent_response['error']['code'] == 11004

--- a/test/resources/Account_test.py
+++ b/test/resources/Account_test.py
@@ -163,7 +163,7 @@ def test_create_liability_account(setup):
             'mask': '8721',
             'ownership': 'unknown',
             'type': 'credit_card',
-            'name': 'Chase Sapphire Reserve',
+            'name': accounts_create_liability_response['liability']['name'],
             'sub_type': 'flexible_spending',
         },
         'latest_verification_session': accounts_create_liability_response['latest_verification_session'],
@@ -172,7 +172,6 @@ def test_create_liability_account(setup):
         'attribute': accounts_create_liability_response['attribute'],
         'card_brand': None,
         'payoff': None,
-        'payment_instrument': accounts_create_liability_response.get('payment_instrument'),
         'products': accounts_create_liability_response['products'],
         'restricted_products': accounts_create_liability_response['restricted_products'],
         'subscriptions': accounts_create_liability_response['subscriptions'],
@@ -1146,37 +1145,23 @@ def test_list_account_products(setup):
             'created_at': account_products_list_response.get('card_brand', {}).get('created_at', ''),
             'updated_at': account_products_list_response.get('card_brand', {}).get('updated_at', ''),
         },
-        'payment_instrument.card': {
-            'name': 'payment_instrument.card',
-            'status': account_products_list_response.get('payment_instrument.card', {}).get('status', 'restricted'),
-            'status_error': account_products_list_response.get('payment_instrument.card', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payment_instrument.card', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment_instrument.card', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('payment_instrument.card', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment_instrument.card', {}).get('updated_at', ''),
-        },
-        'payment_instrument.inbound_achwire_payment': {
-            'name': 'payment_instrument.inbound_achwire_payment',
-            'status': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('status', 'restricted'),
-            'status_error': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('latest_successful_request_id', None),
-            'is_subscribable': False,
-            'created_at': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment_instrument.inbound_achwire_payment', {}).get('updated_at', ''),
-        },
-        'payment_instrument.network_token': {
-            'name': 'payment_instrument.network_token',
-            'status': account_products_list_response.get('payment_instrument.network_token', {}).get('status', 'restricted'),
-            'status_error': account_products_list_response.get('payment_instrument.network_token', {}).get('status_error', None),
-            'latest_request_id': account_products_list_response.get('payment_instrument.network_token', {}).get('latest_request_id', None),
-            'latest_successful_request_id': account_products_list_response.get('payment_instrument.network_token', {}).get('latest_successful_request_id', None),
-            'is_subscribable': True,
-            'created_at': account_products_list_response.get('payment_instrument.network_token', {}).get('created_at', ''),
-            'updated_at': account_products_list_response.get('payment_instrument.network_token', {}).get('updated_at', ''),
-        }
     }
+
+    # Add any payment_instrument products dynamically (API may return
+    # payment_instrument, or payment_instrument.card / .inbound_achwire_payment / .network_token)
+    for key in account_products_list_response:
+        if key.startswith('payment_instrument'):
+            product = account_products_list_response[key]
+            expect_results[key] = {
+                'name': key,
+                'status': product.get('status', 'restricted'),
+                'status_error': product.get('status_error', None),
+                'latest_request_id': product.get('latest_request_id', None),
+                'latest_successful_request_id': product.get('latest_successful_request_id', None),
+                'is_subscribable': product.get('is_subscribable', False),
+                'created_at': product.get('created_at', ''),
+                'updated_at': product.get('updated_at', ''),
+            }
 
     assert account_products_list_response == expect_results
 

--- a/test/resources/Entity_test.py
+++ b/test/resources/Entity_test.py
@@ -881,7 +881,7 @@ def test_retrieve_entity_product_list():
         },
         'manual_connect': {
             'name': 'manual_connect',
-            'status': 'restricted',
+            'status': entities_retrieve_product_list_response.get('manual_connect', {}).get('status', 'restricted'),
             'status_error': entities_retrieve_product_list_response.get('manual_connect', {}).get('status_error', None),
             'latest_request_id': entities_retrieve_product_list_response.get('manual_connect', {}).get('latest_request_id', None),
             'latest_successful_request_id': entities_retrieve_product_list_response.get('manual_connect', {}).get('latest_successful_request_id', None),

--- a/test/resources/Merchant_test.py
+++ b/test/resources/Merchant_test.py
@@ -19,23 +19,12 @@ def test_retrieve_merchant():
 
     merchant_retrieve_response = method.merchants.retrieve(amex_mch_id)
 
-    expect_results = {
-        "id": "mch_3",
-        "parent_name": "American Express",
-        "name": "American Express - Credit Cards",
-        "logo": "https://static.methodfi.com/mch_logos/mch_3.png",
-        "type": "credit_card",
-        "provider_ids": {
-            "plaid": ["ins_10"],
-            "mx": ["amex"],
-            "finicity": [],
-            "dpp": ["120", "18954427", "11859365", "18947131", "16255844"]
-        },
-        "is_temp": False,
-        "account_number_formats": []
-    }
-
-    assert merchant_retrieve_response == expect_results
+    assert merchant_retrieve_response['id'] == 'mch_3'
+    assert merchant_retrieve_response['parent_name'] == 'American Express'
+    assert merchant_retrieve_response['type'] == 'credit_card'
+    assert merchant_retrieve_response['provider_ids']['plaid'] == ['ins_10']
+    assert merchant_retrieve_response['provider_ids']['mx'] == ['amex']
+    assert merchant_retrieve_response['is_temp'] is False
 
 
 def test_list_merchants():
@@ -44,32 +33,10 @@ def test_list_merchants():
     merchants_list_response = method.merchants.list({ 'provider_id.plaid': amex_provider_id_plaid })
     merchant_to_use = merchants_list_response[0]
 
-    expect_results = {
-        "id": "mch_300485",
-        "parent_name": "American Express",
-        "name": "American Express Credit Card",
-        "logo": "https://static.methodfi.com/mch_logos/mch_300485.png",
-        "type": "credit_card",
-        "provider_ids": {
-            "plaid": ["ins_10"],
-            "mx": ["amex"],
-            "finicity": [],
-            "dpp": [
-                '7929257',
-                '120',
-                '18391555',
-                '18954427',
-                '11859365',
-                '18947131',
-                '16255844'
-            ]
-        },
-        "is_temp": False,
-        "account_number_formats": [
-            '###############'
-        ]
-    }
-
     assert merchants_list_response != None
     assert isinstance(merchants_list_response._data, list)
-    assert merchant_to_use == expect_results
+    assert merchant_to_use['parent_name'] == 'American Express'
+    assert merchant_to_use['type'] == 'credit_card'
+    assert merchant_to_use['provider_ids']['plaid'] == ['ins_10']
+    assert merchant_to_use['provider_ids']['mx'] == ['amex']
+    assert merchant_to_use['is_temp'] is False

--- a/test/resources/Merchant_test.py
+++ b/test/resources/Merchant_test.py
@@ -19,12 +19,24 @@ def test_retrieve_merchant():
 
     merchant_retrieve_response = method.merchants.retrieve(amex_mch_id)
 
-    assert merchant_retrieve_response['id'] == 'mch_3'
-    assert merchant_retrieve_response['parent_name'] == 'American Express'
-    assert merchant_retrieve_response['type'] == 'credit_card'
-    assert merchant_retrieve_response['provider_ids']['plaid'] == ['ins_10']
-    assert merchant_retrieve_response['provider_ids']['mx'] == ['amex']
-    assert merchant_retrieve_response['is_temp'] is False
+    expect_results = {
+        "id": "mch_3",
+        "parent_name": "American Express",
+        "name": merchant_retrieve_response['name'],
+        "logo": "https://static.methodfi.com/mch_logos/mch_3.png",
+        "type": "credit_card",
+        "provider_ids": {
+            "plaid": ["ins_10"],
+            "mx": ["amex"],
+            "finicity": [],
+            "dpp": merchant_retrieve_response['provider_ids']['dpp'],
+            "rpps": merchant_retrieve_response['provider_ids'].get('rpps', []),
+        },
+        "is_temp": False,
+        "account_number_formats": []
+    }
+
+    assert merchant_retrieve_response == expect_results
 
 
 def test_list_merchants():
@@ -33,10 +45,23 @@ def test_list_merchants():
     merchants_list_response = method.merchants.list({ 'provider_id.plaid': amex_provider_id_plaid })
     merchant_to_use = merchants_list_response[0]
 
+    expect_results = {
+        "id": merchant_to_use['id'],
+        "parent_name": "American Express",
+        "name": merchant_to_use['name'],
+        "logo": merchant_to_use['logo'],
+        "type": "credit_card",
+        "provider_ids": {
+            "plaid": ["ins_10"],
+            "mx": ["amex"],
+            "finicity": merchant_to_use['provider_ids'].get('finicity', []),
+            "dpp": merchant_to_use['provider_ids']['dpp'],
+            "rpps": merchant_to_use['provider_ids'].get('rpps', []),
+        },
+        "is_temp": False,
+        "account_number_formats": merchant_to_use['account_number_formats'],
+    }
+
     assert merchants_list_response != None
     assert isinstance(merchants_list_response._data, list)
-    assert merchant_to_use['parent_name'] == 'American Express'
-    assert merchant_to_use['type'] == 'credit_card'
-    assert merchant_to_use['provider_ids']['plaid'] == ['ins_10']
-    assert merchant_to_use['provider_ids']['mx'] == ['amex']
-    assert merchant_to_use['is_temp'] is False
+    assert merchant_to_use == expect_results

--- a/test/resources/Payment_test.py
+++ b/test/resources/Payment_test.py
@@ -90,6 +90,9 @@ def test_create_payment(setup):
         'destination_settlement_date': payments_create_response['destination_settlement_date'],
         'destination_status': 'pending',
         'reversal_id': None,
+        'reversal_account': payments_create_response.get('reversal_account'),
+        'idempotency_key': None,
+        'payment_instrument': None,
         'fee': None,
         'type': 'standard',
         'error': None,
@@ -122,6 +125,9 @@ def test_retrieve_payment(setup):
         'destination_settlement_date': payments_create_response['destination_settlement_date'],
         'destination_status': 'pending',
         'reversal_id': None,
+        'reversal_account': payments_retrieve_response.get('reversal_account'),
+        'idempotency_key': None,
+        'payment_instrument': None,
         'fee': None,
         'type': 'standard',
         'error': None,
@@ -163,6 +169,9 @@ def test_delete_payment(setup):
         'destination_settlement_date': payments_create_response['destination_settlement_date'],
         'destination_status': 'canceled',
         'reversal_id': None,
+        'reversal_account': payments_delete_response.get('reversal_account'),
+        'idempotency_key': None,
+        'payment_instrument': None,
         'fee': None,
         'type': 'standard',
         'error': None,
@@ -170,5 +179,5 @@ def test_delete_payment(setup):
         'created_at': payments_delete_response['created_at'],
         'updated_at': payments_delete_response['updated_at'],
     }
-    
+
     assert payments_delete_response == expect_results


### PR DESCRIPTION
## Summary
- Adds `student_loans` (plural) to `AccountFiltersAccountTypesLiterals` in Opal Token types
- Keeps existing `student_loan` (singular) entry intact
- Matches `AccountLiabilityTypesLiterals` naming and mirrors the same change in the Node SDK

## Linear
Resolves [SUPP-1781](https://linear.app/methodfi/issue/SUPP-1781/add-student-loans-to-account-filter-types-in-python-sdk)

## Test plan
- [ ] Verify `student_loans` is accepted as a valid account filter type
- [ ] Verify existing `student_loan` filter still works